### PR TITLE
Update MOCKING.mdx

### DIFF
--- a/docs/docs/guides/MOCKING.mdx
+++ b/docs/docs/guides/MOCKING.mdx
@@ -12,7 +12,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The provided library doesn't work on simulators. These steps allow you to mock the library
 and use it for developing or testing. Based on
-[Detox Mock Guide](https://github.com/wix/Detox/blob/master/docs/Guide.Mocking.md).
+[Detox Mock Guide](https://github.com/wix/Detox/blob/master/docs/guide/mocking.md).
 
 ### Configure the Metro bundler
 


### PR DESCRIPTION
## Link to Detox Mocking Guide has changed (possibly)

Documentation Change in https://www.react-native-vision-camera.com/docs/guides/mocking

https://github.com/wix/Detox/blob/master/docs/Guide.Mocking.md => https://github.com/wix/Detox/blob/master/docs/guide/mocking.md

## Changes
No Logic Changes

## Tested on

Web

## Related issues